### PR TITLE
Nova wallet fix

### DIFF
--- a/src/components/WalletModal/WalletModal.tsx
+++ b/src/components/WalletModal/WalletModal.tsx
@@ -38,7 +38,7 @@ const WalletModal: React.FC<WalletModalProps> = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
 
   const handleWalletClick = (walletId: string, isAvailable: boolean, url: string) => {
-    if (isAvailable) {
+    if (isAvailable || walletId === 'nova') {
       walletSelected(walletId);
       localStorage.setItem(SELECTED_WALLET_KEY, walletId);
       onClose();


### PR DESCRIPTION
 So far, it is possible to connect via Nova Wallet; however, the app recognizes it as PolkadotJS, so the user has to click on the PolkadotJS icon to connect.