### PR TITLE
Renewal status specific to parachain

### DIFF
--- a/src/components/Home/HomeDashboard/ParachainInfoCard/ParachainSelect.tsx
+++ b/src/components/Home/HomeDashboard/ParachainInfoCard/ParachainSelect.tsx
@@ -34,26 +34,29 @@ export const ParachainSelect = ({ selected, setSelected, onSelectParaId }: Props
       const pname = meta?.name || `Parachain`;
       const logo = meta?.logo as string | undefined;
 
-      const match = Array.from(potentialRenewals.entries()).find(
-        ([key, record]) =>
-          (record.completion as any)?.value?.[0]?.assignment?.value === item.id &&
-          saleInfo?.regionBegin === key.when
-      );
-      const coreForLabel =
-        (match?.[0] as RenewalKey | undefined)?.core !== undefined
-          ? Number((match![0] as RenewalKey).core)
-          : undefined;
+      const getAssignmentId = (record: any) =>
+      record?.completion?.value?.[0]?.assignment?.value;
 
-      const renewalStatus = match ? 'Needs Renewal' : 'Renewed';
-      const badgeColor = match ? '#dc2626' : '#0cc184';
+      const hasRenewalAt = (when: number) =>
+        Array.from(potentialRenewals.entries()).some(
+          ([key, record]) => getAssignmentId(record) === item.id && key?.when === when
+        );
+
+      const { regionBegin, regionEnd } = saleInfo ?? {};
+      const regionDuration = (regionEnd ?? 0) - (regionBegin ?? 0);
+
+      const renewForNext = regionBegin != null && hasRenewalAt(regionBegin);
+      const renewForCurrent = regionBegin != null && hasRenewalAt(regionBegin - regionDuration);
+
+      const requiresRenewal = !renewForNext && !! renewForCurrent;
+
+      const renewalStatus = requiresRenewal ? "Needs renewal" : "Renewed";
+      const badgeColor = requiresRenewal ? "#dc2626" : "#0cc184";
 
       return {
-        key: `${item.id}-${coreForLabel ?? 'current'}`,
+        key: `${item.id}`,
         value: item,
-        label:
-          coreForLabel !== undefined
-            ? `${pname} · ParaID ${item.id} · Core ${coreForLabel}`
-            : `${pname} · ParaID ${item.id}`,
+        label: `${pname} · ParaID ${item.id}`,
         icon: logo ? (
           <img
             src={logo}

--- a/src/components/Home/HomeDashboard/ParachainInfoCard/ParachainSelect.tsx
+++ b/src/components/Home/HomeDashboard/ParachainInfoCard/ParachainSelect.tsx
@@ -34,8 +34,7 @@ export const ParachainSelect = ({ selected, setSelected, onSelectParaId }: Props
       const pname = meta?.name || `Parachain`;
       const logo = meta?.logo as string | undefined;
 
-      const getAssignmentId = (record: any) =>
-      record?.completion?.value?.[0]?.assignment?.value;
+      const getAssignmentId = (record: any) => record?.completion?.value?.[0]?.assignment?.value;
 
       const hasRenewalAt = (when: number) =>
         Array.from(potentialRenewals.entries()).some(
@@ -48,10 +47,10 @@ export const ParachainSelect = ({ selected, setSelected, onSelectParaId }: Props
       const renewForNext = regionBegin != null && hasRenewalAt(regionBegin);
       const renewForCurrent = regionBegin != null && hasRenewalAt(regionBegin - regionDuration);
 
-      const requiresRenewal = !renewForNext && !! renewForCurrent;
+      const requiresRenewal = !renewForNext && !!renewForCurrent;
 
-      const renewalStatus = requiresRenewal ? "Needs renewal" : "Renewed";
-      const badgeColor = requiresRenewal ? "#dc2626" : "#0cc184";
+      const renewalStatus = requiresRenewal ? 'Needs renewal' : 'Renewed';
+      const badgeColor = requiresRenewal ? '#dc2626' : '#0cc184';
 
       return {
         key: `${item.id}`,

--- a/src/components/Home/HomeDashboard/ParachainInfoCard/index.tsx
+++ b/src/components/Home/HomeDashboard/ParachainInfoCard/index.tsx
@@ -79,9 +79,7 @@ export default function ParachainInfoCard({ onSelectParaId, initialParaId }: Pro
     if (!saleInfo || !selected) return;
 
     const hasRenewalAt = (when: number) =>
-    Array.from(potentialRenewals.entries()).find(
-      ([key, _record]) => key?.when === when
-    );
+      Array.from(potentialRenewals.entries()).find(([key, _record]) => key?.when === when);
 
     const { regionBegin, regionEnd } = saleInfo ?? {};
     const regionDuration = (regionEnd ?? 0) - (regionBegin ?? 0);
@@ -89,7 +87,7 @@ export default function ParachainInfoCard({ onSelectParaId, initialParaId }: Pro
     const renewForNext = regionBegin != null && hasRenewalAt(regionBegin);
     const renewForCurrent = regionBegin != null && hasRenewalAt(regionBegin - regionDuration);
 
-    const requiresRenewal = !renewForNext && !! renewForCurrent;
+    const requiresRenewal = !renewForNext && !!renewForCurrent;
 
     setRenewalEntry(requiresRenewal ? renewForCurrent : null);
   }, [potentialRenewals, selected, saleInfo]);

--- a/src/components/Home/HomeDashboard/ParachainInfoCard/index.tsx
+++ b/src/components/Home/HomeDashboard/ParachainInfoCard/index.tsx
@@ -77,12 +77,21 @@ export default function ParachainInfoCard({ onSelectParaId, initialParaId }: Pro
 
   useEffect(() => {
     if (!saleInfo || !selected) return;
-    const match = Array.from(potentialRenewals.entries()).find(
-      ([key, record]) =>
-        (record.completion as any)?.value?.[0]?.assignment?.value === selected.id &&
-        saleInfo.regionBegin === key.when
+
+    const hasRenewalAt = (when: number) =>
+    Array.from(potentialRenewals.entries()).find(
+      ([key, _record]) => key?.when === when
     );
-    setRenewalEntry(match ?? null);
+
+    const { regionBegin, regionEnd } = saleInfo ?? {};
+    const regionDuration = (regionEnd ?? 0) - (regionBegin ?? 0);
+
+    const renewForNext = regionBegin != null && hasRenewalAt(regionBegin);
+    const renewForCurrent = regionBegin != null && hasRenewalAt(regionBegin - regionDuration);
+
+    const requiresRenewal = !renewForNext && !! renewForCurrent;
+
+    setRenewalEntry(requiresRenewal ? renewForCurrent : null);
   }, [potentialRenewals, selected, saleInfo]);
 
   useEffect(() => {

--- a/src/components/Home/HomeDashboard/UrgentRenewals/index.tsx
+++ b/src/components/Home/HomeDashboard/UrgentRenewals/index.tsx
@@ -80,22 +80,20 @@ export default function UrgentRenewals({ view }: Props) {
         const meta = chainData[network]?.[paraId];
         const name = meta?.name ?? `Parachain ${paraId}`;
         const logo = meta?.logo as string | undefined;
- 
+
         const hasRenewalAt = (when: number) =>
-          Array.from(potentialRenewals.entries()).some(
-            ([key, _record]) => key?.when === when
-          );
-  
+          Array.from(potentialRenewals.entries()).some(([key, _record]) => key?.when === when);
+
         const { regionBegin, regionEnd } = saleInfo ?? {};
         const regionDuration = (regionEnd ?? 0) - (regionBegin ?? 0);
-  
+
         const renewForNext = regionBegin != null && hasRenewalAt(regionBegin);
         const renewForCurrent = regionBegin != null && hasRenewalAt(regionBegin - regionDuration);
-  
-        const requiresRenewal = !renewForNext && !! renewForCurrent;
-  
-        const renewalStatus = requiresRenewal ? "Needs renewal" : "Renewed";
-        const badgeColor = requiresRenewal ? "#dc2626" : "#0cc184";
+
+        const requiresRenewal = !renewForNext && !!renewForCurrent;
+
+        const renewalStatus = requiresRenewal ? 'Needs renewal' : 'Renewed';
+        const badgeColor = requiresRenewal ? '#dc2626' : '#0cc184';
 
         return {
           key: `${renewal[0].when}-${renewal[0].core}`,

--- a/src/components/Home/HomeDashboard/UrgentRenewals/index.tsx
+++ b/src/components/Home/HomeDashboard/UrgentRenewals/index.tsx
@@ -80,14 +80,22 @@ export default function UrgentRenewals({ view }: Props) {
         const meta = chainData[network]?.[paraId];
         const name = meta?.name ?? `Parachain ${paraId}`;
         const logo = meta?.logo as string | undefined;
-
-        const renewalMatch = Array.from(potentialRenewals.entries()).find(
-          ([key, record]) =>
-            (record.completion as any)?.value?.[0]?.assignment?.value === paraId &&
-            saleInfo?.regionBegin === key.when
-        );
-        const renewalStatus = renewalMatch ? 'Needs Renewal' : 'Renewed';
-        const badgeColor = renewalMatch ? '#dc2626' : '#0cc184';
+ 
+        const hasRenewalAt = (when: number) =>
+          Array.from(potentialRenewals.entries()).some(
+            ([key, _record]) => key?.when === when
+          );
+  
+        const { regionBegin, regionEnd } = saleInfo ?? {};
+        const regionDuration = (regionEnd ?? 0) - (regionBegin ?? 0);
+  
+        const renewForNext = regionBegin != null && hasRenewalAt(regionBegin);
+        const renewForCurrent = regionBegin != null && hasRenewalAt(regionBegin - regionDuration);
+  
+        const requiresRenewal = !renewForNext && !! renewForCurrent;
+  
+        const renewalStatus = requiresRenewal ? "Needs renewal" : "Renewed";
+        const badgeColor = requiresRenewal ? "#dc2626" : "#0cc184";
 
         return {
           key: `${renewal[0].when}-${renewal[0].core}`,

--- a/src/pages/parachain-dashboard/index.tsx
+++ b/src/pages/parachain-dashboard/index.tsx
@@ -122,13 +122,12 @@ const ParachainDashboard = () => {
     paraId: number
   ): { label: 'Renewed' | 'Needs Renewal'; color: string; key: 'renewed' | 'needs' } => {
     if (!saleInfo) return { label: 'Renewed', color: '#8899A8', key: 'renewed' };
-    const getAssignmentId = (record: any) =>
-    record?.completion?.value?.[0]?.assignment?.value;
+    const getAssignmentId = (record: any) => record?.completion?.value?.[0]?.assignment?.value;
 
     const hasRenewalAt = (when: number) =>
-    Array.from(potentialRenewals.entries()).some(
-      ([key, record]) => getAssignmentId(record) === paraId && key?.when === when
-    );
+      Array.from(potentialRenewals.entries()).some(
+        ([key, record]) => getAssignmentId(record) === paraId && key?.when === when
+      );
 
     const { regionBegin, regionEnd } = saleInfo ?? {};
     const regionDuration = (regionEnd ?? 0) - (regionBegin ?? 0);
@@ -136,7 +135,7 @@ const ParachainDashboard = () => {
     const renewForNext = regionBegin != null && hasRenewalAt(regionBegin);
     const renewForCurrent = regionBegin != null && hasRenewalAt(regionBegin - regionDuration);
 
-    const requiresRenewal = !renewForNext && !! renewForCurrent;
+    const requiresRenewal = !renewForNext && !!renewForCurrent;
 
     if (requiresRenewal) return { label: 'Needs Renewal', color: '#dc2626', key: 'needs' };
     return { label: 'Renewed', color: '#15803d', key: 'renewed' };


### PR DESCRIPTION
Instead of showing it specific to the core, we now show it specific to the parachain.

This fixes the issue where “Needs renewal” appears when a parachain has multiple cores and one of them isn’t renewed.